### PR TITLE
Change cosmos sdk and comet bft imports to point to stream forks

### DIFF
--- a/protocol/go.mod
+++ b/protocol/go.mod
@@ -419,10 +419,10 @@ replace (
 	// TODO(https://github.com/cosmos/rosetta/issues/76): Rosetta requires cosmossdk.io/core v0.12.0 erroneously but
 	// should use v0.11.0. The Cosmos build fails with types/context.go:65:29: undefined: comet.BlockInfo otherwise.
 	cosmossdk.io/core => cosmossdk.io/core v0.11.0
-	// Use dYdX fork of CometBFT
-	github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20240409171441-6d0767b72c06
-	// Use dYdX fork of Cosmos SDK
-	github.com/cosmos/cosmos-sdk => github.com/dydxprotocol/cosmos-sdk v0.50.5-0.20240220212824-35f31482370c
+	// Use Stream fork of CometBFT
+	github.com/cometbft/cometbft => github.com/StreamFinance-Protocol/cometbft v0.0.0-20240409171441-c50784d39a5f
+	// Use Stream fork of Cosmos SDK
+	github.com/cosmos/cosmos-sdk => github.com/StreamFinance-Protocol/cosmos-sdk v0.50.5-0.20240220212824-35f31482370c
 	//github.com/cosmos/iavl => github.com/dydxprotocol/iavl v1.1.1-0.20240408175732-0fca9d69cbc4
 	github.com/ethos-works/ethos-avs => ./ethos/ethos-avs
 	github.com/ethos-works/ethos/ethos-chain => ./ethos/ethos-chain

--- a/protocol/go.sum
+++ b/protocol/go.sum
@@ -697,6 +697,10 @@ github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT
 github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
+github.com/StreamFinance-Protocol/cometbft v0.0.0-20240409171441-c50784d39a5f h1:pQEozYPJ920N5eWk54Epr9rZZeeI2Gw/BtQhs1I6LLU=
+github.com/StreamFinance-Protocol/cometbft v0.0.0-20240409171441-c50784d39a5f/go.mod h1:REQN+ObgfYxi39TcYR/Hv95C9bPxY3sYJCvghryj7vY=
+github.com/StreamFinance-Protocol/cosmos-sdk v0.50.5-0.20240220212824-35f31482370c h1:VMdEDmd4rGiPDplpB1N+DVH2D35Lf9/1V8znN+4P12c=
+github.com/StreamFinance-Protocol/cosmos-sdk v0.50.5-0.20240220212824-35f31482370c/go.mod h1:AgkOyykpqwdRuf8cLqoA6PxNZC6ODwNmPrEGYuRzBFY=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
 github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
@@ -942,10 +946,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20240409171441-6d0767b72c06 h1:Dh5Eweh06inJdgYjQBI7ivoaYFKooAmKYAXbZmliSa8=
-github.com/dydxprotocol/cometbft v0.38.6-0.20240409171441-6d0767b72c06/go.mod h1:REQN+ObgfYxi39TcYR/Hv95C9bPxY3sYJCvghryj7vY=
-github.com/dydxprotocol/cosmos-sdk v0.50.5-0.20240220212824-35f31482370c h1:vTcPGxL/uU0MF/Wfzi3G0uzLweEj/417qs1enjf0q60=
-github.com/dydxprotocol/cosmos-sdk v0.50.5-0.20240220212824-35f31482370c/go.mod h1:AgkOyykpqwdRuf8cLqoA6PxNZC6ODwNmPrEGYuRzBFY=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9ndfrgrXUbOGObLHKBR4Fl3nZXwM2c7OYTT8hM=


### PR DESCRIPTION
Changelist
Changed the cometbft import to point to this [commit](https://github.com/StreamFinance-Protocol/cometbft/commit/c50784d39a5f9b8a138d883924884ff2d822d454) of the Stream fork. This is the latest verified commit of the forked repo.
Changed the cosmos sdk import to point to this [commit](https://github.com/StreamFinance-Protocol/cosmos-sdk/commit/35f31482370cb678a8ea73ef43242ba268332a75) of the Stream fork. This is the same commit that the previous import was pointing to.
Relevant for implementing batch cancel orders
Test Plan
Tested using standard testing procedure.

Ran and passed test-slow
Ran and passed e2e tests
Ran and passed indexer tests
Ran and passed ethos test-integration
Ran and passed ethos e2e tests
