### PR TITLE
Prep Protos for NPM registry public access

### DIFF
--- a/v4-proto-js/package.json
+++ b/v4-proto-js/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@klyraprotocol/v4-proto",
-  "version": "0.0.0",
+  "name": "@klyra/proto",
+  "version": "0.0.1",
   "access": "public",
-  "description": "Protos for Klyra v4 protocol",
+  "description": "Protos for Klyra",
   "author": "Klyra Trading Inc.",
-  "homepage": "https://github.com/dydxprotocol/v4-chain",
+  "homepage": "https://github.com/StreamFinance-Protocol/stream-chain",
   "license": "AGPL-3.0",
   "main": "main/index.js",
   "module": "module/index.js",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dydxprotocol/v4-chain"
+    "url": "https://github.com/StreamFinance-Protocol/stream-chain"
   },
   "keywords": [],
   "bugs": {


### PR DESCRIPTION
In this PR, we change the package.json to prep it for launch on the npm registry for public access. This includes versioning, changing name to klyra, and adding correct links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package name and version for better identification.
	- Simplified project description for clarity.
	- New homepage and repository links to reflect the current project ownership.
	- Updated bugs section to direct users to the new issues page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->