### PR TITLE
Bugfix: Same router in both taker and maker order causes panic

### DIFF
--- a/protocol/x/clob/keeper/process_single_match.go
+++ b/protocol/x/clob/keeper/process_single_match.go
@@ -271,29 +271,45 @@ func (k Keeper) persistMatchedOrders(
 	}
 
 	if !isTakerLiquidation {
-		if matchWithOrders.TakerOrder.MustGetOrder().RouterSubaccountId != nil && bigRouterTakerFeeQuoteQuantums.Sign() != 0 {
-			fmt.Printf("bigRouterTakerFeeQuoteQuantums: %v\n", bigRouterTakerFeeQuoteQuantums)
-			updates = append(updates, satypes.Update{
-				AssetUpdates: []satypes.AssetUpdate{
-					{
-						AssetId:          assettypes.AssetTDai.Id,
-						BigQuantumsDelta: bigRouterTakerFeeQuoteQuantums,
+		takerRouter := matchWithOrders.TakerOrder.MustGetOrder().RouterSubaccountId
+		makerRouter := matchWithOrders.MakerOrder.MustGetOrder().RouterSubaccountId
+
+		if takerRouter != nil && makerRouter != nil && *takerRouter == *makerRouter {
+			totalRouterFee := new(big.Int).Add(bigRouterTakerFeeQuoteQuantums, bigRouterMakerFeeQuoteQuantums)
+			if totalRouterFee.Sign() != 0 {
+				updates = append(updates, satypes.Update{
+					AssetUpdates: []satypes.AssetUpdate{
+						{
+							AssetId:          assettypes.AssetTDai.Id,
+							BigQuantumsDelta: totalRouterFee,
+						},
 					},
-				},
-				SubaccountId: *matchWithOrders.TakerOrder.MustGetOrder().RouterSubaccountId,
-			})
-		}
-		if matchWithOrders.MakerOrder.MustGetOrder().RouterSubaccountId != nil && bigRouterMakerFeeQuoteQuantums.Sign() != 0 {
-			fmt.Printf("bigRouterMakerFeeQuoteQuantums: %v\n", bigRouterMakerFeeQuoteQuantums)
-			updates = append(updates, satypes.Update{
-				AssetUpdates: []satypes.AssetUpdate{
-					{
-						AssetId:          assettypes.AssetTDai.Id,
-						BigQuantumsDelta: bigRouterMakerFeeQuoteQuantums,
+					SubaccountId: *takerRouter,
+				})
+			}
+		} else {
+			if takerRouter != nil && bigRouterTakerFeeQuoteQuantums.Sign() != 0 {
+				updates = append(updates, satypes.Update{
+					AssetUpdates: []satypes.AssetUpdate{
+						{
+							AssetId:          assettypes.AssetTDai.Id,
+							BigQuantumsDelta: bigRouterTakerFeeQuoteQuantums,
+						},
 					},
-				},
-				SubaccountId: *matchWithOrders.MakerOrder.MustGetOrder().RouterSubaccountId,
-			})
+					SubaccountId: *takerRouter,
+				})
+			}
+			if makerRouter != nil && bigRouterMakerFeeQuoteQuantums.Sign() != 0 {
+				updates = append(updates, satypes.Update{
+					AssetUpdates: []satypes.AssetUpdate{
+						{
+							AssetId:          assettypes.AssetTDai.Id,
+							BigQuantumsDelta: bigRouterMakerFeeQuoteQuantums,
+						},
+					},
+					SubaccountId: *makerRouter,
+				})
+			}
 		}
 	}
 

--- a/protocol/x/subaccounts/keeper/oimf.go
+++ b/protocol/x/subaccounts/keeper/oimf.go
@@ -58,10 +58,10 @@ func GetDeltaOpenInterestFromUpdates(
 		return nil
 	}
 
-	if len(settledUpdates) < 2 {
+	if len(settledUpdates) < 2 || len(settledUpdates) > 4 {
 		panic(
 			fmt.Sprintf(
-				types.ErrMatchUpdatesMustHaveTwoOrMoreUpdates,
+				types.ErrMatchUpdatesMustHaveTwoToFourUpdates,
 				settledUpdates,
 			),
 		)

--- a/protocol/x/subaccounts/keeper/oimf.go
+++ b/protocol/x/subaccounts/keeper/oimf.go
@@ -108,8 +108,8 @@ func GetDeltaOpenInterestFromUpdates(
 
 	updatedPerpId := perpUpdate0.PerpetualId
 
-	if (perpUpdate0.BigQuantumsDelta.Sign()*perpUpdate1.BigQuantumsDelta.Sign() > 0) ||
-		perpUpdate0.BigQuantumsDelta.CmpAbs(perpUpdate1.BigQuantumsDelta) != 0 {
+	if areBothPerpUpdatesOnSameSide(perpUpdate0, perpUpdate1) ||
+		arePerpUpdatesDifferentSize(perpUpdate0, perpUpdate1) {
 		panic(
 			fmt.Sprintf(
 				types.ErrMatchUpdatesInvalidSize,
@@ -135,4 +135,18 @@ func GetDeltaOpenInterestFromUpdates(
 		PerpetualId:  updatedPerpId,
 		BaseQuantums: baseQuantumsDelta,
 	}
+}
+
+func areBothPerpUpdatesOnSameSide(
+	perpUpdate0 types.PerpetualUpdate,
+	perpUpdate1 types.PerpetualUpdate,
+) bool {
+	return perpUpdate0.BigQuantumsDelta.Sign()*perpUpdate1.BigQuantumsDelta.Sign() > 0
+}
+
+func arePerpUpdatesDifferentSize(
+	perpUpdate0 types.PerpetualUpdate,
+	perpUpdate1 types.PerpetualUpdate,
+) bool {
+	return perpUpdate0.BigQuantumsDelta.CmpAbs(perpUpdate1.BigQuantumsDelta) != 0
 }

--- a/protocol/x/subaccounts/keeper/oimf_test.go
+++ b/protocol/x/subaccounts/keeper/oimf_test.go
@@ -50,7 +50,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 					},
 				},
 			},
-			panicErr: types.ErrMatchUpdatesMustHaveTwoOrMoreUpdates,
+			panicErr: types.ErrMatchUpdatesMustHaveTwoToFourUpdates,
 		},
 		"Invalid: one of two updates contains no perp update": {
 			updateType: types.Match,
@@ -458,7 +458,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 				BaseQuantums: big.NewInt(500),
 			},
 		},
-		"Valid: three routers": {
+		"Invalid: three routers": {
 			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
@@ -517,10 +517,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 					},
 				},
 			},
-			expectedVal: &perptypes.OpenInterestDelta{
-				PerpetualId:  1,
-				BaseQuantums: big.NewInt(500),
-			},
+			panicErr: types.ErrMatchUpdatesMustHaveTwoToFourUpdates,
 		},
 	}
 

--- a/protocol/x/subaccounts/keeper/oimf_test.go
+++ b/protocol/x/subaccounts/keeper/oimf_test.go
@@ -19,6 +19,15 @@ var (
 	bobSubaccountId = &types.SubaccountId{
 		Owner: "Bob",
 	}
+	carlSubaccountId = &types.SubaccountId{
+		Owner: "Carl",
+	}
+	daveSubaccountId = &types.SubaccountId{
+		Owner: "Dave",
+	}
+	emilySubaccountId = &types.SubaccountId{
+		Owner: "Emily",
+	}
 )
 
 func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
@@ -41,9 +50,9 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 					},
 				},
 			},
-			panicErr: types.ErrMatchUpdatesMustHaveTwoUpdates,
+			panicErr: types.ErrMatchUpdatesMustHaveTwoOrMoreUpdates,
 		},
-		"Invalid: one of the updates contains no perp update": {
+		"Invalid: one of two updates contains no perp update": {
 			updateType: types.Match,
 			settledUpdates: []keeper.SettledUpdate{
 				{
@@ -63,7 +72,7 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 					},
 				},
 			},
-			panicErr: types.ErrMatchUpdatesMustUpdateOnePerp,
+			panicErr: types.ErrMatchUpdatesMustHaveTwoPerpetualUpdates,
 		},
 		"Invalid: updates are on different perpetuals": {
 			updateType: types.Match,
@@ -352,6 +361,165 @@ func TestGetDeltaOpenInterestFromUpdates(t *testing.T) {
 			expectedVal: &perptypes.OpenInterestDelta{
 				PerpetualId:  1000,
 				BaseQuantums: big.NewInt(1900),
+			},
+		},
+		"Valid: one router": {
+			updateType: types.Match,
+			settledUpdates: []keeper.SettledUpdate{
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: carlSubaccountId,
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          0,
+							BigQuantumsDelta: big.NewInt(100),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: aliceSubaccountId,
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1,
+							BigQuantumsDelta: big.NewInt(500),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: bobSubaccountId,
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1,
+							BigQuantumsDelta: big.NewInt(-500),
+						},
+					},
+				},
+			},
+			expectedVal: &perptypes.OpenInterestDelta{
+				PerpetualId:  1,
+				BaseQuantums: big.NewInt(500),
+			},
+		},
+		"Valid: two routers": {
+			updateType: types.Match,
+			settledUpdates: []keeper.SettledUpdate{
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: carlSubaccountId,
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          0,
+							BigQuantumsDelta: big.NewInt(100),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: aliceSubaccountId,
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1,
+							BigQuantumsDelta: big.NewInt(500),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: daveSubaccountId,
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          0,
+							BigQuantumsDelta: big.NewInt(100),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: bobSubaccountId,
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1,
+							BigQuantumsDelta: big.NewInt(-500),
+						},
+					},
+				},
+			},
+			expectedVal: &perptypes.OpenInterestDelta{
+				PerpetualId:  1,
+				BaseQuantums: big.NewInt(500),
+			},
+		},
+		"Valid: three routers": {
+			updateType: types.Match,
+			settledUpdates: []keeper.SettledUpdate{
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: carlSubaccountId,
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          0,
+							BigQuantumsDelta: big.NewInt(100),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: aliceSubaccountId,
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1,
+							BigQuantumsDelta: big.NewInt(500),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: daveSubaccountId,
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          0,
+							BigQuantumsDelta: big.NewInt(100),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: bobSubaccountId,
+					},
+					PerpetualUpdates: []types.PerpetualUpdate{
+						{
+							PerpetualId:      1,
+							BigQuantumsDelta: big.NewInt(-500),
+						},
+					},
+				},
+				{
+					SettledSubaccount: types.Subaccount{
+						Id: emilySubaccountId,
+					},
+					AssetUpdates: []types.AssetUpdate{
+						{
+							AssetId:          0,
+							BigQuantumsDelta: big.NewInt(100),
+						},
+					},
+				},
+			},
+			expectedVal: &perptypes.OpenInterestDelta{
+				PerpetualId:  1,
+				BaseQuantums: big.NewInt(500),
 			},
 		},
 	}

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -9,7 +9,9 @@ import (
 
 // Panic strings
 const (
-	ErrMatchUpdatesMustHaveTwoUpdates = "internalCanUpdateSubaccounts: MATCH subaccount updates must consist of " +
+	ErrMatchUpdatesMustHaveTwoPerpetualUpdates = "internalCanUpdateSubaccounts: MATCH subaccount updates must consist of " +
+		"exactly 2 perpetual updates, got settledUpdates: %+v"
+	ErrMatchUpdatesMustHaveTwoOrMoreUpdates = "internalCanUpdateSubaccounts: MATCH subaccount updates must consist of " +
 		"exactly 2 updates, got settledUpdates: %+v"
 	ErrMatchUpdatesMustUpdateOnePerp = "internalCanUpdateSubaccounts: MATCH subaccount updates must each have " +
 		"exactly 1 PerpetualUpdate, got settledUpdates: %+v"

--- a/protocol/x/subaccounts/types/errors.go
+++ b/protocol/x/subaccounts/types/errors.go
@@ -11,8 +11,8 @@ import (
 const (
 	ErrMatchUpdatesMustHaveTwoPerpetualUpdates = "internalCanUpdateSubaccounts: MATCH subaccount updates must consist of " +
 		"exactly 2 perpetual updates, got settledUpdates: %+v"
-	ErrMatchUpdatesMustHaveTwoOrMoreUpdates = "internalCanUpdateSubaccounts: MATCH subaccount updates must consist of " +
-		"exactly 2 updates, got settledUpdates: %+v"
+	ErrMatchUpdatesMustHaveTwoToFourUpdates = "internalCanUpdateSubaccounts: MATCH subaccount updates must consist of " +
+		"exactly 2 to 4 updates, got settledUpdates: %+v"
 	ErrMatchUpdatesMustUpdateOnePerp = "internalCanUpdateSubaccounts: MATCH subaccount updates must each have " +
 		"exactly 1 PerpetualUpdate, got settledUpdates: %+v"
 	ErrMatchUpdatesMustBeSamePerpId = "internalCanUpdateSubaccounts: MATCH subaccount updates must consists of two " +


### PR DESCRIPTION
### Changelist
- Adapt fee update logic to be able to handle the same router subaccount for both taker and maker order of a match
- Add testing for the above
- Generalize GetDeltaOpenInterestFromUpdates to handle zero to two routers
- Expand testing for GetDeltaOpenInterestFromUpdates

### Testing
- Added tests for changes made
- Unit, Integration, End-to-End, and Indexer Tests Passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced handling of router fees for both maker and taker orders, allowing for more streamlined processing.
	- Expanded test scenarios to validate the new router fee logic and ensure robustness.

- **Bug Fixes**
	- Improved error messaging for update validation, clarifying requirements for the number of perpetual updates.

- **Documentation**
	- Updated error constants for better clarity on update requirements related to subaccounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->