### PR TITLE
Ender collat pool fix

### DIFF
--- a/indexer/packages/postgres/__tests__/helpers/constants.ts
+++ b/indexer/packages/postgres/__tests__/helpers/constants.ts
@@ -705,6 +705,13 @@ export const defaultCollateralPool2: CollateralPoolsCreateObject = {
   quoteAssetId: 1,
 };
 
+export const collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock: CollateralPoolsCreateObject = {
+  id: 2,
+  maxCumulativeInsuranceFundDeltaPerBlock: '',
+  multiCollateralAssets: '{0}',
+  quoteAssetId: 0,
+};
+
 // ============== OraclePrices ==============
 
 export const defaultOraclePrice: OraclePriceCreateObject = {

--- a/indexer/packages/postgres/__tests__/stores/collateral-pool-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/collateral-pool-table.test.ts
@@ -4,6 +4,7 @@ import { UniqueViolationError } from 'objection';
 import {
   defaultCollateralPool,
   defaultCollateralPool2,
+  collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock,
 } from '../helpers/constants';
 import * as CollateralPoolTable from '../../src/stores/collateral-pools-table';
 
@@ -110,6 +111,14 @@ describe('CollateralPool store', () => {
 
     expect(collateralPool).toEqual(
       normalizeCollateralPool(defaultCollateralPool),
+    );
+  });
+
+  it('Successfully inserts a collateral pool with an empty cumulative insurance fund delta per block', async () => {
+    const collateralPool = await CollateralPoolTable.upsert(collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock);
+
+    expect(collateralPool).toEqual(
+      normalizeCollateralPool(collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock),
     );
   });
 });

--- a/indexer/packages/postgres/__tests__/stores/collateral-pool-table.test.ts
+++ b/indexer/packages/postgres/__tests__/stores/collateral-pool-table.test.ts
@@ -118,7 +118,10 @@ describe('CollateralPool store', () => {
     const collateralPool = await CollateralPoolTable.upsert(collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock);
 
     expect(collateralPool).toEqual(
-      normalizeCollateralPool(collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock),
+      normalizeCollateralPool({
+        ...collateralPoolEmptyCumulativeInsuranceFundDeltaPerBlock,
+        maxCumulativeInsuranceFundDeltaPerBlock: '0',
+      }),
     );
   });
 });

--- a/indexer/packages/postgres/src/models/collateral-pool-model.ts
+++ b/indexer/packages/postgres/src/models/collateral-pool-model.ts
@@ -25,7 +25,9 @@ export default class CollateralPoolsModel extends BaseModel {
         id: { type: 'integer' },
         maxCumulativeInsuranceFundDeltaPerBlock: {
           type: 'string',
+          default: '0',
           postgresql: { type: 'bigint' },
+          parse: (value: string) => value === '' ? '0' : value,
         },
         multiCollateralAssets: {
           type: 'string',

--- a/indexer/packages/postgres/src/models/collateral-pool-model.ts
+++ b/indexer/packages/postgres/src/models/collateral-pool-model.ts
@@ -25,9 +25,7 @@ export default class CollateralPoolsModel extends BaseModel {
         id: { type: 'integer' },
         maxCumulativeInsuranceFundDeltaPerBlock: {
           type: 'string',
-          default: '0',
           postgresql: { type: 'bigint' },
-          parse: (value: string) => value === '' ? '0' : value,
         },
         multiCollateralAssets: {
           type: 'string',

--- a/indexer/packages/postgres/src/stores/collateral-pools-table.ts
+++ b/indexer/packages/postgres/src/stores/collateral-pools-table.ts
@@ -102,10 +102,18 @@ export async function upsert(
   collateralPoolToUpsert: CollateralPoolsCreateObject,
   options: Options = { txId: undefined },
 ): Promise<CollateralPoolFromDatabase> {
+  const cleanedCollateralPool = {
+    ...collateralPoolToUpsert,
+    maxCumulativeInsuranceFundDeltaPerBlock: 
+      collateralPoolToUpsert.maxCumulativeInsuranceFundDeltaPerBlock === '' 
+        ? '0' 
+        : collateralPoolToUpsert.maxCumulativeInsuranceFundDeltaPerBlock,
+  };
+
   const collateralPools: CollateralPoolsModel[] = await CollateralPoolsModel.query(
     Transaction.get(options.txId),
   )
-    .upsert(collateralPoolToUpsert)
+    .upsert(cleanedCollateralPool)
     .returning('*');
   // should only ever be one collateral pool
   return collateralPools[0];

--- a/protocol/x/clob/keeper/msg_server_place_order_test.go
+++ b/protocol/x/clob/keeper/msg_server_place_order_test.go
@@ -113,6 +113,7 @@ func TestPlaceOrder_Error(t *testing.T) {
 				mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 				mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			).Return(mockLogger)
+			mockLogger.On("Info", mock.Anything, mock.Anything, mock.Anything).Return()
 			if errors.Is(tc.ExpectedError, types.ErrStatefulOrderCollateralizationCheckFailed) {
 				mockLogger.On("Info",
 					mock.Anything,

--- a/protocol/x/perpetuals/keeper/perpetual.go
+++ b/protocol/x/perpetuals/keeper/perpetual.go
@@ -1852,8 +1852,20 @@ func (k Keeper) UpsertCollateralPool(
 		}
 	}
 
-	// Set collateral pool in store.
 	k.writeCollateralPoolToStore(ctx, collateralPool)
+
+	log.InfoLog(ctx,
+		fmt.Sprintf(
+			"UpsertCollateralPool: Emitting CollateralPoolUpsertEvent with id=%v,"+
+				"maxCumulativeInsuranceFundDeltaPerBlock=%v,"+
+				"multiCollateralAssets=%v,"+
+				"quoteAssetId=%v",
+			collateralPoolId,
+			maxCumulativeInsuranceFundDeltaPerBlock,
+			multiCollateralAssets.MultiCollateralAssets,
+			quoteAssetId,
+		),
+	)
 
 	k.GetIndexerEventManager().AddTxnEvent(
 		ctx,


### PR DESCRIPTION
### Changelist
Gracefully handle sporadic error stemming from empty maxCumulativeInsuranceFundDeltaPerBlock in collateral pool event. Add logs to chain to catch this error and test for this case.

### Test Screenshots
Unit, integration, and indexer tests working. e2e tests failing.

### Author/Reviewer Checklist
- [ ] Comment commits / questions that arise when reviewing
- [ ] Re-run all tests (stream e2e, protocol test-slow, indexer tests if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an improved collateral pool configuration that automatically normalizes fund values for more reliable operations.
  - Enhanced logging for collateral pool updates and order placement errors to provide better operational traceability.

- **Tests**
  - Added a test case to verify that collateral pool insertions correctly convert empty cumulative insurance values to a standardized value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->